### PR TITLE
feat(signup) : 회원가입(signup)페이지 구현

### DIFF
--- a/src/pages/SignUpPage/SignUpPage.style.ts
+++ b/src/pages/SignUpPage/SignUpPage.style.ts
@@ -1,0 +1,84 @@
+import styled from 'styled-components';
+
+export const FormContainer = styled.div`
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+`;
+
+export const FormName = styled.div`
+  font-size: 30px;
+  font-weight: bolder;
+  margin-bottom: 20px;
+`;
+
+export const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  row-gap: 7px;
+  padding: 30px;
+  width: 90vw;
+  max-width: 410px;
+  border-radius: 4px;
+  border: none;
+  border: 1px solid lightgray;
+`;
+
+export const FormInput = styled.input`
+  font-size: 14px;
+  width: 100%;
+  height: 50px;
+  border-radius: 4px;
+  padding: 10px 8px 10px 8px;
+  border: none;
+  border: 1px solid lightgray;
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+export const MoveButton = styled.button`
+  cursor: pointer;
+  font-size: 15px;
+  margin-top: 20px;
+  width: 410px;
+  height: 60px;
+  border-radius: 4px;
+  border: none;
+  border: 1px solid lightgray;
+  background-color: transparent;
+
+  > .bold {
+    font-weight: 600;
+  }
+`;
+
+export const SubmitButton = styled.button`
+  cursor: pointer;
+  width: 100%;
+  height: 45px;
+  border: none;
+  border-radius: 4px;
+  color: white;
+  font-size: 15px;
+  font-weight: 600;
+  background-color: #576cbc;
+
+  &:hover {
+    opacity: 0.8;
+  }
+
+  &:disabled {
+    background-color: lightgray;
+  }
+`;
+
+export const ErrorMessage = styled.div`
+  font-size: 14px;
+  color: #cd1818;
+`;

--- a/src/pages/SignUpPage/index.tsx
+++ b/src/pages/SignUpPage/index.tsx
@@ -1,10 +1,61 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import * as S from './SignUpPage.style';
+import useInput from '../../hooks/useInput';
 
 const SignUpPage = () => {
+  const {
+    value: email,
+    setValue: setEmail,
+    isError: isEmailError,
+  } = useInput({
+    regex: /@/,
+    initialValue: '',
+  });
+  const {
+    value: password,
+    setValue: setPassword,
+    isError: isPasswordError,
+  } = useInput({
+    regex: /^.{8,}$/,
+    initialValue: '',
+  });
+  const isFormValid = !isEmailError && !isPasswordError;
+
   return (
-    <section>
-      <h1>회원가입 페이지입니다.</h1>
-    </section>
+    <S.FormContainer>
+      <S.FormName>회원가입</S.FormName>
+      <S.Form>
+        <S.FormInput
+          data-testid="email-input"
+          type="text"
+          value={email}
+          placeholder="이메일을 입력해 주세요"
+          onChange={e => setEmail(e.target.value)}
+        />
+        {email !== '' && isEmailError && (
+          <S.ErrorMessage>올바르지 않은 이메일 형식입니다.</S.ErrorMessage>
+        )}
+        <S.FormInput
+          data-testid="password-input"
+          type="password"
+          value={password}
+          placeholder="비밀번호를 입력해 주세요"
+          onChange={e => setPassword(e.target.value)}
+        />
+        {password !== '' && isPasswordError && (
+          <S.ErrorMessage>비밀번호는 8자 이상이어야 합니다.</S.ErrorMessage>
+        )}
+        <S.SubmitButton data-testid="signup-button" type="submit" disabled={!isFormValid}>
+          회원가입
+        </S.SubmitButton>
+      </S.Form>
+      <Link to="/signin">
+        <S.MoveButton>
+          계정이 있으신가요? <span className="bold">로그인</span>
+        </S.MoveButton>
+      </Link>
+    </S.FormContainer>
   );
 };
 


### PR DESCRIPTION
## Related issue
close #11 

## Result
![스크린샷(701)](https://github.com/wanted-internship-12-9/pre-onboarding-12th-1-9/assets/86523545/13dd01d2-5f50-4f4b-9938-16642dd4b66e)


## Work list
- styled-component로 스타일링
- useInput 훅 연결

## Discussion
- styled-component 이용해 스타일링을 해두었습니다. 페이지 도메인의 style은 따로 두는게 좋다고 생각해 기존 style 폴더에 하나로 묶여있던 style들을 각 폴더 하위의 style.ts 파일에 배치하였습니다. 
- 아직 api 연결은 하지 않아서 로그인 페이지와 마찬가지로, 차미님과 이야기 후 구현 예정입니다.