### PR TITLE
feat(main) : 메인(root)페이지 구현

### DIFF
--- a/src/components/AuthLayout/index.tsx
+++ b/src/components/AuthLayout/index.tsx
@@ -11,10 +11,13 @@ const AuthLayout = () => {
     if (currentPath === '/todo' && !accessToken) {
       navigate('/signin');
     }
-    if ((currentPath === '/signin' || currentPath === '/signup') && accessToken) {
+    if (
+      (currentPath === '/' || currentPath === '/signin' || currentPath === '/signup') &&
+      accessToken
+    ) {
       navigate('/todo');
     }
-  }, [currentPath]);
+  }, [currentPath, accessToken]);
 
   return <Outlet />;
 };

--- a/src/pages/RootPage/RootPage.style.ts
+++ b/src/pages/RootPage/RootPage.style.ts
@@ -1,9 +1,52 @@
 import styled from 'styled-components';
 
-const Header = styled.h1`
-  font-size: 2rem;
-  font-weight: 700;
-  margin: 0;
+export const ButtonContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  row-gap: 20px;
+  padding: 30px;
+  width: 90vw;
+  max-width: 410px;
+  border-radius: 4px;
+  border: 1px solid lightgray;
+
+  > a {
+    width: 100%;
+  }
 `;
 
-export { Header };
+export const FormContainer = styled.div`
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+`;
+
+export const FormTitle = styled.div`
+  font-size: 30px;
+  font-weight: bolder;
+  margin-bottom: 20px;
+`;
+
+export const ActionButton = styled.button`
+  width: 100%;
+  height: 45px;
+  border: none;
+  border-radius: 4px;
+  color: white;
+  font-size: 15px;
+  font-weight: 600;
+  background-color: #576cbc;
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.8;
+  }
+
+  &:disabled {
+    background-color: lightgray;
+  }
+`;

--- a/src/pages/RootPage/index.tsx
+++ b/src/pages/RootPage/index.tsx
@@ -1,20 +1,20 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { FormContainer, FormTitle, ButtonContainer, ActionButton } from './RootPage.style';
+import * as S from './RootPage.style';
 
 const RootPage = () => {
   return (
-    <FormContainer>
-      <FormTitle>TODO LIST</FormTitle>
-      <ButtonContainer>
+    <S.FormContainer>
+      <S.FormTitle>TODO LIST</S.FormTitle>
+      <S.ButtonContainer>
         <Link to="/signin">
-          <ActionButton>로그인</ActionButton>
+          <S.ActionButton>로그인</S.ActionButton>
         </Link>
         <Link to="/signup">
-          <ActionButton>회원가입</ActionButton>
+          <S.ActionButton>회원가입</S.ActionButton>
         </Link>
-      </ButtonContainer>
-    </FormContainer>
+      </S.ButtonContainer>
+    </S.FormContainer>
   );
 };
 

--- a/src/pages/RootPage/index.tsx
+++ b/src/pages/RootPage/index.tsx
@@ -1,12 +1,20 @@
 import React from 'react';
-
-import * as S from './RootPage.style';
+import { Link } from 'react-router-dom';
+import { FormContainer, FormTitle, ButtonContainer, ActionButton } from './RootPage.style';
 
 const RootPage = () => {
   return (
-    <section>
-      <S.Header>루트(메인) 페이지입니다.</S.Header>
-    </section>
+    <FormContainer>
+      <FormTitle>TODO LIST</FormTitle>
+      <ButtonContainer>
+        <Link to="/signin">
+          <ActionButton>로그인</ActionButton>
+        </Link>
+        <Link to="/signup">
+          <ActionButton>회원가입</ActionButton>
+        </Link>
+      </ButtonContainer>
+    </FormContainer>
   );
 };
 

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -11,8 +11,8 @@ const Router = () => {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<RootPage />} />
         <Route element={<AuthLayout />}>
+          <Route path="/" element={<RootPage />} />
           <Route path="signup" element={<SignUpPage />} />
           <Route path="signin" element={<SignInPage />} />
           <Route path="todo" element={<TodoPage />} />


### PR DESCRIPTION
# Related issue
#5 

# Result
<img width="504" alt="image" src="https://github.com/wanted-internship-12-9/pre-onboarding-12th-1-9/assets/126763111/e266e02f-b130-4ccf-a411-ce22b996f54a">

# Work list
- root page 구현 및 스타일링
- router에서 rootPage를 AuthLayout 하위로 이동
- AuthLayout 리다이렉트 조건에 '/' 경로 추가

# Discussion
- 추후 변수명 등은 한번에 통일성있게 다듬어야할것 같습니다.