### PR TITLE
feat(signup) : 회원가입페이지 api 연결 

### DIFF
--- a/src/pages/SignUpPage/index.tsx
+++ b/src/pages/SignUpPage/index.tsx
@@ -1,9 +1,16 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import * as S from './SignUpPage.style';
 import useInput from '../../hooks/useInput';
+import { SignUpRequest } from '../../types/auth';
+import { axiosFetch } from '../../api/axiosInstance';
+import { API_PATH } from '../../api/apiConfig';
+import axios from 'axios';
 
 const SignUpPage = () => {
+  const navigate = useNavigate()
+const [errorMessage,setErrorMessage]=useState('')
+
   const {
     value: email,
     setValue: setEmail,
@@ -22,10 +29,29 @@ const SignUpPage = () => {
   });
   const isFormValid = !isEmailError && !isPasswordError;
 
+  const signUp = async({email,password}:SignUpRequest)=>{
+    try{
+      const response = await axiosFetch.post(API_PATH.AUTH.SIGN_UP,{email,password})
+      if(response?.status===201){
+        alert('성공적으로 가입되었습니다!\n로그인페이지로 이동합니다.');
+    navigate('/signin');
+      }
+    }catch(error){
+      if(axios.isAxiosError(error)){
+        setErrorMessage(error.response?.data.message)
+      }
+    }
+  }
+
+const handleSubmit=(event:React.FormEvent<HTMLFormElement>)=>{
+  event.preventDefault()
+  signUp({email,password})
+}
+
   return (
     <S.FormContainer>
       <S.FormName>회원가입</S.FormName>
-      <S.Form>
+      <S.Form onSubmit={handleSubmit}>
         <S.FormInput
           data-testid="email-input"
           type="text"
@@ -46,6 +72,7 @@ const SignUpPage = () => {
         {password !== '' && isPasswordError && (
           <S.ErrorMessage>비밀번호는 8자 이상이어야 합니다.</S.ErrorMessage>
         )}
+        {errorMessage && <S.ErrorMessage>{errorMessage}</S.ErrorMessage>}
         <S.SubmitButton data-testid="signup-button" type="submit" disabled={!isFormValid}>
           회원가입
         </S.SubmitButton>


### PR DESCRIPTION
# Related issue
#15 

# Result
<img width="489" alt="image" src="https://github.com/wanted-internship-12-9/pre-onboarding-12th-1-9/assets/126763111/7b8dd639-8cd2-4f16-a718-1159516dae76">

# Work list
- 회원가입 요청 api 연결 
- 회원가입 성공 시 로그인페이지로 리다이렉트

# Discussion
- 에러메시지 노출 위치를 signin페이지와 동일하게 맞췄습니다.
- 서버에서 보내주는 에러메시지를 그대로 적용하는 방식으로 에러를 처리했습니다.