### PR TITLE
feat(todoItem) : 투두아이템(TodoItem)컴포넌트 구현

### DIFF
--- a/src/components/TodoITem/index.tsx
+++ b/src/components/TodoITem/index.tsx
@@ -1,0 +1,144 @@
+import React, { useRef, useState } from 'react';
+import { styled } from 'styled-components';
+import { axiosFetch } from '../../api/axiosInstance';
+import { API_PATH } from '../../api/apiConfig';
+
+interface TodoItemProps {
+  id: number;
+  todo: string;
+  isCompleted: boolean;
+}
+
+const TodoItem = ({ id, todo, isCompleted }: TodoItemProps) => {
+  const [isEdited, setIsEdited] = useState<boolean>(false);
+  const editedTodoRef = useRef<HTMLInputElement>(null);
+  const [todoText, setTodoText] = useState<string | undefined>(todo);
+
+  const onEditedModeToggle = () => setIsEdited(prev => !prev);
+
+  const onTodoDelete = async () => {
+    if (!confirm('정말로 삭제하시겠습니까?')) {
+      return;
+    }
+    try {
+      await axiosFetch.delete(`${API_PATH.TODOS}/${id}`);
+    } catch (err) {
+      alert(err);
+    }
+    // getTodos();  // get 요청 부분
+  };
+  const onTodoCompleted = async () => {
+    try {
+      await axiosFetch.put(`${API_PATH.TODOS}/${id}`, {
+        todo: todoText,
+        isCompleted: !isCompleted,
+      });
+    } catch (err) {
+      alert(err);
+    }
+  };
+  const onEditedTodoSubmit = async () => {
+    if (!confirm('이 내용으로 수정하시겠습니까?')) {
+      return;
+    }
+    try {
+      await axiosFetch.put(`${API_PATH.TODOS}/${id}`, {
+        todo: editedTodoRef.current?.value,
+        isCompleted,
+      });
+      setTodoText(editedTodoRef.current?.value);
+      // getTodos();  // get 요청 부분
+    } catch (err) {
+      alert(err);
+    }
+  };
+  return (
+    <TodoItemContainer>
+      <input type="checkbox" defaultChecked={isCompleted} onClick={onTodoCompleted} />
+      {!isEdited ? (
+        <TodoContent>
+          <TodoText>{todoText}</TodoText>
+          <ButtonContainer>
+            <Button onClick={onEditedModeToggle}>수정</Button>
+            <Button onClick={onTodoDelete}>삭제</Button>
+          </ButtonContainer>
+        </TodoContent>
+      ) : (
+        <TodoEditor>
+          <EditedInput
+            autoFocus
+            type="text"
+            defaultValue={todoText}
+            ref={editedTodoRef}
+            placeholder="할 일을 수정 해주세요."
+          />
+          <ButtonContainer>
+            <Button onClick={onEditedTodoSubmit}>제출</Button>
+            <Button onClick={onEditedModeToggle}>취소</Button>
+          </ButtonContainer>
+        </TodoEditor>
+      )}
+    </TodoItemContainer>
+  );
+};
+
+export default TodoItem;
+
+const TodoItemContainer = styled.li`
+  display: flex;
+  width: 100%;
+  padding: 10px;
+  height: 3em;
+  align-items: center;
+`;
+
+const TodoContent = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const TodoText = styled.span`
+  display: flex;
+  margin: auto 0;
+  padding: 0px 70px 0px 15px;
+  font-size: 15px;
+`;
+
+const ButtonContainer = styled.div`
+  & > button:nth-child(2) {
+    margin-left: 10px;
+  }
+  margin-right: 10px;
+`;
+
+const Button = styled.button`
+  font-size: 15px;
+  font-weight: 600;
+  background-color: transparent;
+  border: none;
+`;
+
+const TodoEditor = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const EditedInput = styled.input`
+  font-size: 15px;
+  padding: 0px 70px 0px 15px;
+
+  border: none;
+  width: 80%;
+  height: 40px;
+  border-bottom: solid 1px lightgray;
+
+  &:focus {
+    outline: none;
+    border-bottom: solid 1px black;
+  }
+`;


### PR DESCRIPTION
# Related issue
* closes : #17 

# Result
<img width="680" alt="Screenshot 2023-08-24 at 18 02 08" src="https://github.com/wanted-internship-12-9/pre-onboarding-12th-1-9/assets/68489467/0bab13cf-c88e-4fb5-ae65-2bfcd6276083">
<img width="680" alt="Screenshot 2023-08-24 at 18 02 25" src="https://github.com/wanted-internship-12-9/pre-onboarding-12th-1-9/assets/68489467/4a62b2c9-d0a9-4d58-b9fe-a9aec0bf463d">

# Work list
- 투두아이템(TodoItem 컴포넌트 구현) 했습니다

# Discussion
- 첫 회의때 의견 나눴던 대로, 수정은 낙관적 업데이트에 맡기고 클라이언트 상태(useState)를 사용해서 렌더링 하도록 했습니다.
- 수정 할 때는, useRef 훅을 사용해서 불필요한 리렌더링을 줄일 수 있도록 했습니다
- 서버에서 todo 리스트를 가져오는 함수가 구현되면 반영하도록 하겠습니다
